### PR TITLE
Fixed that DeepLinkInternal crashes on tracking non-hierarchical URIs.

### DIFF
--- a/mobile-engage/src/androidTest/java/com/emarsys/mobileengage/deeplink/DeepLinkInternalTest.java
+++ b/mobile-engage/src/androidTest/java/com/emarsys/mobileengage/deeplink/DeepLinkInternalTest.java
@@ -86,6 +86,13 @@ public class DeepLinkInternalTest {
     }
 
     @Test
+    public void testTrackDeepLink_doesNotCrashOnNonHierarchicalUris() {
+        Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse("mailto:a@b.com"));
+
+        deepLinkInternal.trackDeepLinkOpen(mockActivity, intent, null);
+    }
+
+    @Test
     public void testTrackDeepLink_requestManagerCalled_withCorrectRequestModel() {
         Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse("https://demo-mobileengage.emarsys.net/something?fancy_url=1&ems_dl=1_2_3_4_5"));
 

--- a/mobile-engage/src/main/java/com/emarsys/mobileengage/deeplink/DefaultDeepLinkInternal.java
+++ b/mobile-engage/src/main/java/com/emarsys/mobileengage/deeplink/DefaultDeepLinkInternal.java
@@ -9,6 +9,8 @@ import com.emarsys.core.api.result.CompletionListener;
 import com.emarsys.core.request.RequestManager;
 import com.emarsys.core.request.model.RequestModel;
 import com.emarsys.core.util.Assert;
+import com.emarsys.core.util.log.Logger;
+import com.emarsys.core.util.log.entry.CrashLog;
 import com.emarsys.mobileengage.MobileEngageRequestContext;
 
 import java.util.HashMap;
@@ -38,7 +40,15 @@ public class DefaultDeepLinkInternal implements DeepLinkInternal {
 
         if (!isLinkTracked && uri != null) {
             String ems_dl = "ems_dl";
-            String deepLinkQueryParam = uri.getQueryParameter(ems_dl);
+            String deepLinkQueryParam = null;
+
+            try {
+                deepLinkQueryParam = uri.getQueryParameter(ems_dl);
+            } catch (UnsupportedOperationException e) {
+                CrashLog crashLog = new CrashLog(e);
+                crashLog.getData().put("URI", uri);
+                Logger.log(crashLog);
+            }
 
             if (deepLinkQueryParam != null) {
                 HashMap<String, Object> payload = new HashMap<>();


### PR DESCRIPTION
Port of https://github.com/emartech/android-mobile-engage-sdk/pull/4

Fixed that DeepLinkInternal crashes on tracking non-hierarchical URIs.

### Reason

We were receiving such crashes when our PayPal integration with Braintree Android redirected back from browser to app.

We were never able to reproduce this. Braintree redirects with a hierarchical URL. But still happens from time to time on production with some of our customers.
I asked Braintee whether there's any non-hierarchical URL in the play: https://github.com/braintree/braintree_android/issues/262. Answer: no

So I'd like to offer this preventive change. Couldn't test 

```
Fatal Exception: java.lang.RuntimeException: Unable to start activity ComponentInfo{<application-id>/com.braintreepayments.api.BraintreeBrowserSwitchActivity}: java.lang.UnsupportedOperationException: This isn't a hierarchical URI.
       at android.app.ActivityThread.performLaunchActivity + 3403(ActivityThread.java:3403)
       at android.app.ActivityThread.handleLaunchActivity + 3587(ActivityThread.java:3587)
       at android.app.servertransaction.LaunchActivityItem.execute + 86(LaunchActivityItem.java:86)
       at android.app.servertransaction.TransactionExecutor.executeCallbacks + 108(TransactionExecutor.java:108)
       at android.app.servertransaction.TransactionExecutor.execute + 68(TransactionExecutor.java:68)
       at android.app.ActivityThread$H.handleMessage + 2185(ActivityThread.java:2185)
       at android.os.Handler.dispatchMessage + 112(Handler.java:112)
       at android.os.Looper.loop + 216(Looper.java:216)
       at android.app.ActivityThread.main + 7593(ActivityThread.java:7593)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run + 524(RuntimeInit.java:524)
       at com.android.internal.os.ZygoteInit.main + 987(ZygoteInit.java:987)
Caused by java.lang.UnsupportedOperationException: This isn't a hierarchical URI.
       at android.net.Uri.getQueryParameter + 1699(Uri.java:1699)
       at com.emarsys.mobileengage.deeplink.DeepLinkInternal.trackDeepLinkOpen + 41(DeepLinkInternal.java:41)
       at com.emarsys.mobileengage.deeplink.DeepLinkAction.execute + 20(DeepLinkAction.java:20)
       at com.emarsys.core.activity.ActivityLifecycleWatchdog.onActivityCreated + 50(ActivityLifecycleWatchdog.java:50)
       at android.app.Application.dispatchActivityCreated + 232(Application.java:232)
       at android.app.Activity.onCreate + 1121(Activity.java:1121)
       at com.braintreepayments.browserswitch.BrowserSwitchActivity.onCreate + 20(BrowserSwitchActivity.java:20)
       at android.app.Activity.performCreate + 7458(Activity.java:7458)
       at android.app.Activity.performCreate + 7448(Activity.java:7448)
       at android.app.Instrumentation.callActivityOnCreate + 1286(Instrumentation.java:1286)
       at android.app.ActivityThread.performLaunchActivity + 3382(ActivityThread.java:3382)
       at android.app.ActivityThread.handleLaunchActivity + 3587(ActivityThread.java:3587)
       at android.app.servertransaction.LaunchActivityItem.execute + 86(LaunchActivityItem.java:86)
       at android.app.servertransaction.TransactionExecutor.executeCallbacks + 108(TransactionExecutor.java:108)
       at android.app.servertransaction.TransactionExecutor.execute + 68(TransactionExecutor.java:68)
       at android.app.ActivityThread$H.handleMessage + 2185(ActivityThread.java:2185)
       at android.os.Handler.dispatchMessage + 112(Handler.java:112)
       at android.os.Looper.loop + 216(Looper.java:216)
       at android.app.ActivityThread.main + 7593(ActivityThread.java:7593)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run + 524(RuntimeInit.java:524)
       at com.android.internal.os.ZygoteInit.main + 987(ZygoteInit.java:987)
```
