### PR TITLE
Fixes an crash because of a thrown UnrecoverableKeyException

### DIFF
--- a/core/src/androidTest/java/com/emarsys/core/crypto/SharedPreferenceCryptoTest.kt
+++ b/core/src/androidTest/java/com/emarsys/core/crypto/SharedPreferenceCryptoTest.kt
@@ -4,6 +4,7 @@ import android.security.keystore.KeyProperties
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.mockk.every
+import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import io.mockk.verify
@@ -12,6 +13,7 @@ import org.junit.Before
 import org.junit.Test
 import java.security.GeneralSecurityException
 import java.security.KeyStore
+import java.security.UnrecoverableKeyException
 import javax.crypto.Cipher
 import javax.crypto.KeyGenerator
 
@@ -128,5 +130,21 @@ class SharedPreferenceCryptoTest {
 
         val testCrypto = SharedPreferenceCrypto()
         testCrypto.decrypt(testValue) shouldBe null
+    }
+
+    @Test
+    fun decrypt_shouldCreateNewSecretKeyIfExistingIsNotRecoverable() {
+        mockkStatic(KeyGenerator::class)
+
+        val mockedKeyStore = mockk<KeyStore>(relaxUnitFun = true)
+        every { mockedKeyStore.containsAlias("emarsys_sdk_key_shared_pref_key_v3") } returns true
+        every { mockedKeyStore.getKey("emarsys_sdk_key_shared_pref_key_v3", null) } throws UnrecoverableKeyException()
+
+        mockkStatic(KeyStore::class)
+        every { KeyStore.getInstance("AndroidKeyStore") } returns mockedKeyStore
+
+        SharedPreferenceCrypto()
+
+        verify { KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES) }
     }
 }

--- a/core/src/main/java/com/emarsys/core/crypto/SharedPreferenceCrypto.kt
+++ b/core/src/main/java/com/emarsys/core/crypto/SharedPreferenceCrypto.kt
@@ -7,6 +7,7 @@ import com.emarsys.core.util.log.Logger
 import com.emarsys.core.util.log.entry.StatusLog
 import java.security.GeneralSecurityException
 import java.security.KeyStore
+import java.security.UnrecoverableKeyException
 import javax.crypto.Cipher
 import javax.crypto.KeyGenerator
 import javax.crypto.SecretKey
@@ -64,11 +65,17 @@ class SharedPreferenceCrypto {
         val keyStore = KeyStore.getInstance("AndroidKeyStore")
         keyStore.load(null)
 
-        if (!keyStore.containsAlias(KEYSTORE_ALIAS)) {
+        try {
+            return if (keyStore.containsAlias(KEYSTORE_ALIAS)) {
+                keyStore.getKey(KEYSTORE_ALIAS, null) as SecretKey
+            } else {
+                createSecretKey()
+            }
+        } catch (_: UnrecoverableKeyException) {
+            // If the secret key was unrecoverable (e.g. after backup restore), just create a new one.
+            keyStore.deleteEntry(KEYSTORE_ALIAS)
             return createSecretKey()
         }
-
-        return keyStore.getKey(KEYSTORE_ALIAS, null) as SecretKey
     }
 
     private fun createSecretKey(): SecretKey {


### PR DESCRIPTION
When a user migrates to a new phone or restores their existing phone from a backup, the secret key alias still exists, but the value is unrecoverable. This results in an UnrecoverableKeyException being thrown when using `keyStore.getKey`. As this exception is not handled, this causes a crash. 

This PR handles that exception, by removing the alias and recreating a new secret key. It also adds a unit test for this case.