### PR TITLE
Dev

### DIFF
--- a/.github/workflows/on_push_workflow.yml
+++ b/.github/workflows/on_push_workflow.yml
@@ -63,7 +63,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: dev
           submodules: true
           fetch-depth: 0 # 0 indicates all history
 

--- a/.github/workflows/on_tag_workflow.yml
+++ b/.github/workflows/on_tag_workflow.yml
@@ -97,6 +97,8 @@ jobs:
     name: Release sample app
     runs-on: ubuntu-latest
     needs: [Release, CreateSampleReleaseBundle]
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v3
         with:
@@ -128,12 +130,12 @@ jobs:
       - name: setup RELEASE_VERSION
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
       - name: Create Release Page
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ env.RELEASE_VERSION }}
-          release_name: ${{ github.ref }}
+          name: ${{ github.ref }}
           body_path: changelog.md
           draft: false
           prerelease: false

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,10 @@
 # What's fixed
-### [Emarsys SDK](https://github.com/emartech/android-emarsys-sdk/wiki)
-* Fixed an issue which could cause crash in rare edge cases related to sharedPreferences migration during setup
+### [In-App](https://github.com/emartech/android-emarsys-sdk/wiki#3-inapp)
+* Fixed an issue which could cause crash when an In-App message display failed
 
-# What's changed
+### [Inline In-App](https://github.com/emartech/android-emarsys-sdk/wiki#32-inline-in-app)
+* Fixed an issue which could prevent creating an InlineInAppView when it was not initiated from the main thread
+
 ### [Emarsys SDK](https://github.com/emartech/android-emarsys-sdk/wiki)
-* Improved log filtering
+* Fixed an issue which could cause improper internal behavior in case an empty application code was set
+* Fixed an issue which handles unavailable security system functions more gracefully

--- a/core/src/androidTest/java/com/emarsys/core/api/LogExceptionProxyTest.kt
+++ b/core/src/androidTest/java/com/emarsys/core/api/LogExceptionProxyTest.kt
@@ -80,4 +80,19 @@ class LogExceptionProxyTest  {
         verify { mockLogger.handleLog(LogLevel.ERROR, capture(slot), null) }
         slot.captured.throwable shouldBe expectedCause
     }
+
+    @Test
+    fun testInvoke_shouldNotLogCrash_whenResponseErrorExceptionIsThrown() {
+        val callback = Runnable {
+            throw ResponseErrorException(502, "Bad Gateway", "<html>Bad Gateway</html>")
+        }
+
+        callback.proxyWithLogExceptions().run()
+        val latch = CountDownLatch(1)
+        concurrentHandlerHolder.coreHandler.post {
+            latch.countDown()
+        }
+        latch.await()
+        verify(exactly = 0) { mockLogger.handleLog(LogLevel.ERROR, any(), null) }
+    }
 }

--- a/core/src/androidTest/java/com/emarsys/core/crypto/SharedPreferenceCryptoTest.kt
+++ b/core/src/androidTest/java/com/emarsys/core/crypto/SharedPreferenceCryptoTest.kt
@@ -4,6 +4,7 @@ import android.security.keystore.KeyProperties
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.mockk.every
+import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import io.mockk.verify
@@ -157,5 +158,22 @@ class SharedPreferenceCryptoTest {
         val result = testCrypto.decrypt(testValue)
 
         result shouldBe null
+    }
+
+    @Test
+    fun init_shouldNotThrow_whenKeyStore_load_throwsKeyStoreException() {
+        mockkStatic(KeyStore::class)
+        val mockKeyStore = mockk<KeyStore>(relaxed = true)
+        every { KeyStore.getInstance("AndroidKeyStore") } returns mockKeyStore
+        every { mockKeyStore.load(null) } throws java.security.KeyStoreException("Keystore unavailable")
+
+        var thrownException: Exception? = null
+        try {
+            SharedPreferenceCrypto()
+        } catch (e: Exception) {
+            thrownException = e
+        }
+
+        thrownException shouldBe null
     }
 }

--- a/core/src/androidTest/java/com/emarsys/core/crypto/SharedPreferenceCryptoTest.kt
+++ b/core/src/androidTest/java/com/emarsys/core/crypto/SharedPreferenceCryptoTest.kt
@@ -12,6 +12,7 @@ import org.junit.Before
 import org.junit.Test
 import java.security.GeneralSecurityException
 import java.security.KeyStore
+import java.security.ProviderException
 import javax.crypto.Cipher
 import javax.crypto.KeyGenerator
 
@@ -128,5 +129,33 @@ class SharedPreferenceCryptoTest {
 
         val testCrypto = SharedPreferenceCrypto()
         testCrypto.decrypt(testValue) shouldBe null
+    }
+
+    @Test
+    fun encrypt_shouldNotThrow_whenCreateSecretKey_throwsProviderException_duringRecovery() {
+        val testValue = "testValue"
+        val testCrypto = SharedPreferenceCrypto()
+        mockkStatic(KeyGenerator::class)
+        mockkStatic(Cipher::class)
+        every { Cipher.getInstance("AES/GCM/NoPadding") } throws GeneralSecurityException("Keystore operation failed")
+        every { KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES) } throws ProviderException("Keystore key generation failed")
+
+        val result = testCrypto.encrypt(testValue)
+
+        result shouldBe testValue
+    }
+
+    @Test
+    fun decrypt_shouldNotThrow_whenCreateSecretKey_throwsProviderException_duringRecovery() {
+        val testValue = "dGVzdFZhbHVlU2hvdWxkQmVTaXh0ZWVuQ2hhcnNMb25n"
+        val testCrypto = SharedPreferenceCrypto()
+        mockkStatic(KeyGenerator::class)
+        mockkStatic(Cipher::class)
+        every { Cipher.getInstance("AES/GCM/NoPadding") } throws GeneralSecurityException("Keystore operation failed")
+        every { KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES) } throws ProviderException("Keystore key generation failed")
+
+        val result = testCrypto.decrypt(testValue)
+
+        result shouldBe null
     }
 }

--- a/core/src/main/java/com/emarsys/core/crypto/SharedPreferenceCrypto.kt
+++ b/core/src/main/java/com/emarsys/core/crypto/SharedPreferenceCrypto.kt
@@ -17,16 +17,23 @@ class SharedPreferenceCrypto {
         private const val KEYSTORE_ALIAS = "emarsys_sdk_key_shared_pref_key_v3"
     }
 
-    private var secretKey: SecretKey = getOrCreateSecretKey()
+    private var secretKey: SecretKey? = try {
+        getOrCreateSecretKey()
+    } catch (exception: Exception) {
+        logCryptoError("init", "getOrCreateSecretKey", exception)
+        null
+    }
 
     fun encrypt(value: String): String {
+        val key = secretKey ?: return value
         return try {
-            tryEncrypt(value)
+            tryEncrypt(value, key)
         } catch (exception: GeneralSecurityException) {
             logCryptoError(value, "encrypt", exception)
             try {
-                secretKey = createSecretKey()
-                tryEncrypt(value)
+                val newKey = createSecretKey()
+                secretKey = newKey
+                tryEncrypt(value, newKey)
             } catch (exception: Exception) {
                 logCryptoError(value, "encrypt", exception)
                 value
@@ -35,12 +42,13 @@ class SharedPreferenceCrypto {
     }
 
     fun decrypt(value: String): String? {
+        val key = secretKey ?: return null
         return try {
             val ivBytes = Base64.decode(value.substring(0, 16), Base64.DEFAULT)
             val encryptedBytes = Base64.decode(value.substring(16), Base64.DEFAULT)
 
             val cipher = Cipher.getInstance("AES/GCM/NoPadding")
-            cipher.init(Cipher.DECRYPT_MODE, secretKey, GCMParameterSpec(128, ivBytes))
+            cipher.init(Cipher.DECRYPT_MODE, key, GCMParameterSpec(128, ivBytes))
             val decrypted = cipher.doFinal(encryptedBytes)
             String(decrypted)
         } catch (exception: GeneralSecurityException) {
@@ -90,9 +98,9 @@ class SharedPreferenceCrypto {
         return keyGenerator.generateKey()
     }
 
-    private fun tryEncrypt(value: String): String {
+    private fun tryEncrypt(value: String, key: SecretKey): String {
         val cipher = Cipher.getInstance("AES/GCM/NoPadding")
-        cipher.init(Cipher.ENCRYPT_MODE, secretKey)
+        cipher.init(Cipher.ENCRYPT_MODE, key)
         val encrypted = cipher.doFinal(value.toByteArray())
         val iv = cipher.iv
         val ivBase64 = Base64.encodeToString(iv, Base64.DEFAULT)

--- a/core/src/main/java/com/emarsys/core/crypto/SharedPreferenceCrypto.kt
+++ b/core/src/main/java/com/emarsys/core/crypto/SharedPreferenceCrypto.kt
@@ -24,8 +24,8 @@ class SharedPreferenceCrypto {
             tryEncrypt(value)
         } catch (exception: GeneralSecurityException) {
             logCryptoError(value, "encrypt", exception)
-            secretKey = createSecretKey()
             try {
+                secretKey = createSecretKey()
                 tryEncrypt(value)
             } catch (exception: Exception) {
                 logCryptoError(value, "encrypt", exception)
@@ -45,7 +45,11 @@ class SharedPreferenceCrypto {
             String(decrypted)
         } catch (exception: GeneralSecurityException) {
             logCryptoError(value, "decrypt", exception)
-            secretKey = createSecretKey()
+            try {
+                secretKey = createSecretKey()
+            } catch (exception: Exception) {
+                logCryptoError(value, "decrypt", exception)
+            }
             null
         } catch (exception: IllegalArgumentException) {
             logCryptoError(value, "decrypt", exception)

--- a/core/src/main/java/com/emarsys/core/util/ExceptionExtensions.kt
+++ b/core/src/main/java/com/emarsys/core/util/ExceptionExtensions.kt
@@ -1,5 +1,6 @@
 package com.emarsys.core.util
 
+import com.emarsys.core.api.ResponseErrorException
 import java.net.ConnectException
 import java.net.SocketException
 import java.net.SocketTimeoutException
@@ -21,7 +22,8 @@ fun Throwable.isNetworkException(): Boolean {
         if (cause is UnknownHostException ||
             cause is SocketException ||
             cause is SocketTimeoutException ||
-            cause is ConnectException
+            cause is ConnectException ||
+            cause is ResponseErrorException
         ) return true
         cause = cause.cause
     }

--- a/emarsys-sdk/src/androidTest/java/com/emarsys/config/EmarsysConfigTest.kt
+++ b/emarsys-sdk/src/androidTest/java/com/emarsys/config/EmarsysConfigTest.kt
@@ -255,4 +255,15 @@ class EmarsysConfigTest  {
         result.sharedPackageNames shouldBe expected.sharedPackageNames
         result.verboseConsoleLoggingEnabled shouldBe false
     }
+
+    @Test
+    fun testBuilder_withEmptyApplicationCode_shouldProduceNullApplicationCode() {
+        val result = EmarsysConfig.Builder()
+            .application(application)
+            .applicationCode("")
+            .build()
+
+        result.applicationCode shouldBe null
+    }
+
 }

--- a/emarsys-sdk/src/androidTest/java/com/emarsys/inapp/ui/InlineInAppViewTest.kt
+++ b/emarsys-sdk/src/androidTest/java/com/emarsys/inapp/ui/InlineInAppViewTest.kt
@@ -1,6 +1,7 @@
 package com.emarsys.inapp.ui
 
 
+import android.os.Looper
 import androidx.test.core.app.ActivityScenario
 import com.emarsys.core.CoreCompletionHandler
 import com.emarsys.core.api.ResponseErrorException
@@ -11,6 +12,7 @@ import com.emarsys.core.request.RequestManager
 import com.emarsys.core.request.model.RequestModel
 import com.emarsys.core.response.ResponseModel
 import com.emarsys.di.FakeDependencyContainer
+import com.emarsys.di.emarsys
 import com.emarsys.di.setupEmarsysComponent
 import com.emarsys.mobileengage.iam.jsbridge.IamJsBridge
 import com.emarsys.mobileengage.iam.jsbridge.IamJsBridgeFactory
@@ -315,6 +317,52 @@ class InlineInAppViewTest {
             appEventListener shouldBe mockAppEventListener
             null
         }
+    }
+
+    @Test
+    fun testConstructor_webViewFactory_isCalledOnMainThread_evenWhenConstructedOnBackgroundThread() {
+        val mainLatch = CountDownLatch(1)
+        IntegrationTestUtils.runOnMain {
+            mainLatch.countDown()
+        }
+        mainLatch.await()
+
+        val coreLatch = CountDownLatch(1)
+        emarsys().concurrentHandlerHolder.coreHandler.post {
+            coreLatch.countDown()
+        }
+        coreLatch.await()
+
+        var webViewFactoryCalledOnMainThread: Boolean? = null
+        scenario.onActivity { activity ->
+            val freshIamWebView = spyk(runOnMain {
+                IamWebView(concurrentHandlerHolder, mockIamJsBridgeFactory, mockJsCommandFactory, activity)
+            })
+            val capturingFactory = mockk<IamWebViewFactory>(relaxed = true) {
+                every { create(any()) } answers {
+                    webViewFactoryCalledOnMainThread = Looper.myLooper() == Looper.getMainLooper()
+                    freshIamWebView
+                }
+            }
+            setupEmarsysComponent(
+                FakeDependencyContainer(
+                    webViewFactory = capturingFactory,
+                    concurrentHandlerHolder = concurrentHandlerHolder,
+                    requestManager = mockRequestManager,
+                    mobileEngageRequestModelFactory = mockRequestModelFactory,
+                )
+            )
+
+            val latch = CountDownLatch(1)
+            concurrentHandlerHolder.coreHandler.post {
+                InlineInAppView(activity)
+                latch.countDown()
+            }
+            latch.await()
+        }
+        runOnMain {}
+
+        webViewFactoryCalledOnMainThread shouldBe true
     }
 
     private fun requestManagerRespond(

--- a/emarsys-sdk/src/main/java/com/emarsys/config/EmarsysConfig.kt
+++ b/emarsys-sdk/src/main/java/com/emarsys/config/EmarsysConfig.kt
@@ -98,7 +98,7 @@ data class EmarsysConfig(
                 if (experimentalFeatures == null) emptyList() else experimentalFeatures
             return EmarsysConfig(
                 application,
-                applicationCode,
+                applicationCode?.takeIf { it.isNotBlank() },
                 merchantId,
                 experimentalFeatures!!,
                 automaticPushTokenSending,

--- a/emarsys-sdk/src/main/java/com/emarsys/inapp/ui/InlineInAppView.kt
+++ b/emarsys-sdk/src/main/java/com/emarsys/inapp/ui/InlineInAppView.kt
@@ -1,6 +1,7 @@
 package com.emarsys.inapp.ui
 
 import android.content.Context
+import android.os.Looper
 import android.util.AttributeSet
 import android.view.View
 import android.view.ViewGroup
@@ -67,21 +68,30 @@ class InlineInAppView : LinearLayout {
         val attributes = context.obtainStyledAttributes(attrs, intArray)
         viewId = attributes.getString(0)
 
-        try {
-            iamWebView = webViewFactory.create(context)
-        } catch (e: IamWebViewCreationFailedException) {
-            onCompletionListener?.onCompleted(IllegalArgumentException("WebView can not be created, please try again later!"))
-        }
-        val iamWebView = iamWebView ?: return
-        iamWebView.onAppEventTriggered = onAppEventListener
-        iamWebView.onCloseTriggered = onCloseListener
-        concurrentHandlerHolder.postOnMain {
+        runOnMain {
+            try {
+                iamWebView = webViewFactory.create(context)
+            } catch (e: IamWebViewCreationFailedException) {
+                onCompletionListener?.onCompleted(IllegalArgumentException("WebView can not be created, please try again later!"))
+                return@runOnMain
+            }
+            val iamWebView = iamWebView ?: return@runOnMain
+            iamWebView.onAppEventTriggered = onAppEventListener
+            iamWebView.onCloseTriggered = onCloseListener
             setupViewHierarchy(iamWebView)
             if (viewId != null) {
                 loadInApp(viewId!!)
             }
         }
         attributes.recycle()
+    }
+
+    private fun runOnMain(runnable: () -> Unit) {
+        if (Looper.myLooper() == Looper.getMainLooper()) {
+            runnable()
+        } else {
+            concurrentHandlerHolder.postOnMain(runnable)
+        }
     }
 
     private fun setupViewHierarchy(iamWebView: IamWebView) {

--- a/emarsys/src/androidTest/java/com/emarsys/config/DefaultConfigInternalTest.kt
+++ b/emarsys/src/androidTest/java/com/emarsys/config/DefaultConfigInternalTest.kt
@@ -1238,6 +1238,107 @@ class DefaultConfigInternalTest {
         (configInternal as DefaultConfigInternal).hasFetchedThisSession shouldBe false
     }
 
+    @Test
+    fun testChangeApplicationCode_withEmptyString_shouldTreatAsNull() {
+        val mockContactFieldValueStorage = mockk<StringStorage>(relaxed = true)
+        every { mockContactFieldValueStorage.get() } returns null
+        val realRequestContext = MobileEngageRequestContext(
+            applicationCode = APPLICATION_CODE,
+            contactFieldId = null,
+            openIdToken = null,
+            deviceInfo = mockDeviceInfo,
+            timestampProvider = mockk(relaxed = true),
+            uuidProvider = mockk(relaxed = true),
+            clientStateStorage = mockk(relaxed = true),
+            contactTokenStorage = mockk(relaxed = true),
+            refreshTokenStorage = mockk(relaxed = true),
+            pushTokenStorage = mockk(relaxed = true),
+            contactFieldValueStorage = mockContactFieldValueStorage,
+            sessionIdHolder = mockk(relaxed = true)
+        )
+        val configInternalWithRealContext = DefaultConfigInternal(
+            realRequestContext,
+            mockMobileEngageInternal,
+            mockPushInternal,
+            mockPredictRequestContext,
+            mockDeviceInfo,
+            mockRequestManager,
+            mockEmarsysRequestModelFactory,
+            mockConfigResponseMapper,
+            mockClientServiceStorage,
+            mockEventServiceStorage,
+            mockDeeplinkServiceStorage,
+            mockPredictServiceStorage,
+            mockMessageInboxServiceStorage,
+            mockLogLevelStorage,
+            mockCrypto,
+            mockClientServiceInternal,
+            concurrentHandlerHolder,
+            mockPredictInternal,
+            mockConnectionWatchDog
+        )
+        val latch = CountDownLatch(1)
+
+        configInternalWithRealContext.changeApplicationCode("") { latch.countDown() }
+        latch.await()
+
+        realRequestContext.applicationCode shouldBe null
+    }
+
+    @Test
+    fun testChangeApplicationCode_withEmptyString_doesNotThrowOnSubsequentSdkCalls() {
+        val mockContactFieldValueStorage = mockk<StringStorage>(relaxed = true)
+        every { mockContactFieldValueStorage.get() } returns null
+        val realRequestContext = MobileEngageRequestContext(
+            applicationCode = APPLICATION_CODE,
+            contactFieldId = null,
+            openIdToken = null,
+            deviceInfo = mockDeviceInfo,
+            timestampProvider = mockk(relaxed = true),
+            uuidProvider = mockk(relaxed = true),
+            clientStateStorage = mockk(relaxed = true),
+            contactTokenStorage = mockk(relaxed = true),
+            refreshTokenStorage = mockk(relaxed = true),
+            pushTokenStorage = mockk(relaxed = true),
+            contactFieldValueStorage = mockContactFieldValueStorage,
+            sessionIdHolder = mockk(relaxed = true)
+        )
+        val configInternalWithRealContext = DefaultConfigInternal(
+            realRequestContext,
+            mockMobileEngageInternal,
+            mockPushInternal,
+            mockPredictRequestContext,
+            mockDeviceInfo,
+            mockRequestManager,
+            mockEmarsysRequestModelFactory,
+            mockConfigResponseMapper,
+            mockClientServiceStorage,
+            mockEventServiceStorage,
+            mockDeeplinkServiceStorage,
+            mockPredictServiceStorage,
+            mockMessageInboxServiceStorage,
+            mockLogLevelStorage,
+            mockCrypto,
+            mockClientServiceInternal,
+            concurrentHandlerHolder,
+            mockPredictInternal,
+            mockConnectionWatchDog
+        )
+        val latch = CountDownLatch(1)
+        var caughtException: Throwable? = null
+
+        configInternalWithRealContext.changeApplicationCode("") { latch.countDown() }
+        latch.await()
+
+        try {
+            configInternalWithRealContext.refreshRemoteConfig(null)
+        } catch (e: IllegalArgumentException) {
+            caughtException = e
+        }
+
+        caughtException shouldBe null
+    }
+
     private fun requestManagerWithRestClient(restClient: RestClient): RequestManager {
         val mockDelegatorCompletionHandlerProvider: DelegatorCompletionHandlerProvider =
             mockk(relaxed = true)

--- a/emarsys/src/main/java/com/emarsys/config/DefaultConfigInternal.kt
+++ b/emarsys/src/main/java/com/emarsys/config/DefaultConfigInternal.kt
@@ -131,9 +131,10 @@ class DefaultConfigInternal(
     }
 
     private fun handleAppCodeChange(applicationCode: String?) {
+        val normalizedCode = applicationCode?.takeIf { it.isNotBlank() }
         mobileEngageRequestContext.reset()
-        mobileEngageRequestContext.applicationCode = applicationCode
-        if (applicationCode != null) {
+        mobileEngageRequestContext.applicationCode = normalizedCode
+        if (normalizedCode != null) {
             FeatureRegistry.enableFeature(InnerFeature.MOBILE_ENGAGE)
             FeatureRegistry.enableFeature(InnerFeature.EVENT_SERVICE_V4)
         } else {

--- a/mobile-engage/src/androidTest/java/com/emarsys/mobileengage/deeplink/DeepLinkActionTest.kt
+++ b/mobile-engage/src/androidTest/java/com/emarsys/mobileengage/deeplink/DeepLinkActionTest.kt
@@ -66,4 +66,14 @@ class DeepLinkActionTest  {
 
         verify(exactly = 0) { (mockDeepLinkInternal.trackDeepLinkOpen(any(), any(), any())) }
     }
+
+    @Test
+    fun testExecute_doesNotThrow_whenIntentBecomesNull_betweenCheckAndUse() {
+        val intent: Intent = mockk(relaxed = true)
+        val mockActivity: Activity = mockk(relaxed = true)
+        every { mockActivity.intent } returnsMany listOf(intent, null)
+
+        action.execute(mockActivity)
+        waitForTask()
+    }
 }

--- a/mobile-engage/src/androidTest/java/com/emarsys/mobileengage/iam/dialog/IamDialogTest.kt
+++ b/mobile-engage/src/androidTest/java/com/emarsys/mobileengage/iam/dialog/IamDialogTest.kt
@@ -598,10 +598,11 @@ class IamDialogTest {
         every { mockTimestampProvider.provideTimestamp() } returns 100L
         val loadingTime = InAppLoadingTime(0L, 150L)
 
-        val args = Bundle()
-        args.putString(IamDialog.CAMPAIGN_ID, CAMPAIGN_ID)
-        args.putSerializable(IamDialog.LOADING_TIME, loadingTime)
-        args.putString(IamDialog.REQUEST_ID, REQUEST_ID_KEY)
+        val args = Bundle().apply {
+            putString(IamDialog.CAMPAIGN_ID, CAMPAIGN_ID)
+            putSerializable(IamDialog.LOADING_TIME, loadingTime)
+            putString(IamDialog.REQUEST_ID, REQUEST_ID_KEY)
+        }
 
         iamDialog.arguments = args
 
@@ -618,12 +619,10 @@ class IamDialogTest {
 
         try {
             iamDialog.dismiss()
-        } catch (e: IllegalStateException) {
-            // Testing private fun saveOnScreenTime() here
-            // Catch and ignore IllegalStateException thrown by super.dismiss()
+        } catch (ignoredExceptionFromSuper: IllegalStateException) {
         }
 
-        verify { Logger.metric(match { it.data == expectedLog.data }) }
+        verify { Logger.metric(match { it.topic == expectedLog.topic && it.data == expectedLog.data }) }
     }
 
     @Test
@@ -639,20 +638,19 @@ class IamDialogTest {
 
         try {
             iamDialog.dismiss()
-        } catch (e: IllegalStateException) {
-            // Testing private fun saveOnScreenTime() here
-            // Catch and ignore IllegalStateException thrown by super.dismiss()
+        } catch (ignoredExceptionFromSuper: IllegalStateException) {
         }
 
-        verify { Logger.error(match { it.data == expectedLog.data }) }
+        verify { Logger.error(match { it.topic == expectedLog.topic && it.data == expectedLog.data }) }
     }
 
     @Test
     fun testSaveOnScreenTime_shouldLogAppEventLogWithError_whenCampaignIdIsNull() {
         every { mockTimestampProvider.provideTimestamp() } returns 100L
 
-        val args = Bundle()
-        args.putString(IamDialog.REQUEST_ID, REQUEST_ID_KEY)
+        val args = Bundle().apply {
+            putString(IamDialog.REQUEST_ID, REQUEST_ID_KEY)
+        }
 
         iamDialog.arguments = args
 
@@ -663,21 +661,20 @@ class IamDialogTest {
 
         try {
             iamDialog.dismiss()
-        } catch (e: IllegalStateException) {
-            // Testing private fun saveOnScreenTime() here
-            // Catch and ignore IllegalStateException thrown by super.dismiss()
+        } catch (ignoredExceptionFromSuper: IllegalStateException) {
         }
 
-        verify { Logger.error(match { it.data == expectedLog.data }) }
+        verify { Logger.error(match { it.topic == expectedLog.topic && it.data == expectedLog.data }) }
     }
 
     @Test
     fun testSaveOnScreenTime_shouldLogAppEventLogWithInfo_whenLoadingTimeIsNull() {
         every { mockTimestampProvider.provideTimestamp() } returns 100L
 
-        val args = Bundle()
-        args.putString(IamDialog.CAMPAIGN_ID, CAMPAIGN_ID)
-        args.putString(IamDialog.REQUEST_ID, REQUEST_ID_KEY)
+        val args = Bundle().apply {
+            putString(IamDialog.CAMPAIGN_ID, CAMPAIGN_ID)
+            putString(IamDialog.REQUEST_ID, REQUEST_ID_KEY)
+        }
 
         iamDialog.arguments = args
 
@@ -691,12 +688,10 @@ class IamDialogTest {
 
         try {
             iamDialog.dismiss()
-        } catch (e: IllegalStateException) {
-            // Testing private fun saveOnScreenTime() here
-            // Catch and ignore IllegalStateException thrown by super.dismiss()
+        } catch (ignoredExceptionFromSuper: IllegalStateException) {
         }
 
-        verify { Logger.info(match { it.data == expectedLog.data }) }
+        verify { Logger.info(match { it.topic == expectedLog.topic && it.data == expectedLog.data }) }
     }
 
     private fun createWebView(): IamWebView {

--- a/mobile-engage/src/androidTest/java/com/emarsys/mobileengage/iam/dialog/IamDialogTest.kt
+++ b/mobile-engage/src/androidTest/java/com/emarsys/mobileengage/iam/dialog/IamDialogTest.kt
@@ -13,7 +13,11 @@ import com.emarsys.core.handler.ConcurrentHandlerHolder
 import com.emarsys.core.provider.activity.CurrentActivityProvider
 import com.emarsys.core.provider.timestamp.TimestampProvider
 import com.emarsys.core.provider.uuid.UUIDProvider
+import com.emarsys.core.util.log.Logger
+import com.emarsys.core.util.log.entry.AppEventLog
 import com.emarsys.core.util.log.entry.InAppLoadingTime
+import com.emarsys.core.util.log.entry.InAppLog
+import com.emarsys.core.util.log.entry.OnScreenTime
 import com.emarsys.mobileengage.di.mobileEngage
 import com.emarsys.mobileengage.di.setupMobileEngageComponent
 import com.emarsys.mobileengage.di.tearDownMobileEngageComponent
@@ -35,6 +39,8 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
 import io.mockk.verify
 import org.junit.After
 import org.junit.Before
@@ -99,12 +105,15 @@ class IamDialogTest {
             )
         )
         iamDialog = IamDialog(mockTimestampProvider, mockWebViewFactory)
+
+        mockkStatic(Logger::class)
     }
 
     @After
     fun tearDown() {
         tearDownMobileEngageComponent()
         scenario?.close()
+        unmockkAll()
     }
 
     private fun launchActivityIfNeeded() {
@@ -582,6 +591,112 @@ class IamDialogTest {
 
         verify { firstWebView.load(firstHtml, firstMeta, firstListener) }
         verify { secondWebView.load(secondHtml, secondMeta, secondListener) }
+    }
+
+    @Test
+    fun testSaveOnScreenTime_shouldLogInAppLogWithMetric() {
+        every { mockTimestampProvider.provideTimestamp() } returns 100L
+        val loadingTime = InAppLoadingTime(0L, 150L)
+
+        val args = Bundle()
+        args.putString(IamDialog.CAMPAIGN_ID, CAMPAIGN_ID)
+        args.putSerializable(IamDialog.LOADING_TIME, loadingTime)
+        args.putString(IamDialog.REQUEST_ID, REQUEST_ID_KEY)
+
+        iamDialog.arguments = args
+
+        val expectedLog = InAppLog(
+            loadingTime,
+            OnScreenTime(
+                100L,
+                0,
+                100L
+            ),
+            CAMPAIGN_ID,
+            REQUEST_ID_KEY
+        )
+
+        try {
+            iamDialog.dismiss()
+        } catch (e: IllegalStateException) {
+            // Testing private fun saveOnScreenTime() here
+            // Catch and ignore IllegalStateException thrown by super.dismiss()
+        }
+
+        verify { Logger.metric(match { it.data == expectedLog.data }) }
+    }
+
+    @Test
+    fun testSaveOnScreenTime_shouldLogAppEventLogWithError_whenArgIsNull() {
+        every { mockTimestampProvider.provideTimestamp() } returns 100L
+
+        iamDialog.arguments = null
+
+        val expectedLog = AppEventLog(
+            "reporting iamDialog",
+            mapOf("error" to "iamDialog - arguments has been null")
+        )
+
+        try {
+            iamDialog.dismiss()
+        } catch (e: IllegalStateException) {
+            // Testing private fun saveOnScreenTime() here
+            // Catch and ignore IllegalStateException thrown by super.dismiss()
+        }
+
+        verify { Logger.error(match { it.data == expectedLog.data }) }
+    }
+
+    @Test
+    fun testSaveOnScreenTime_shouldLogAppEventLogWithError_whenCampaignIdIsNull() {
+        every { mockTimestampProvider.provideTimestamp() } returns 100L
+
+        val args = Bundle()
+        args.putString(IamDialog.REQUEST_ID, REQUEST_ID_KEY)
+
+        iamDialog.arguments = args
+
+        val expectedLog = AppEventLog(
+            "reporting iamDialog",
+            mapOf("error" to "iamDialog - campaignId is null")
+        )
+
+        try {
+            iamDialog.dismiss()
+        } catch (e: IllegalStateException) {
+            // Testing private fun saveOnScreenTime() here
+            // Catch and ignore IllegalStateException thrown by super.dismiss()
+        }
+
+        verify { Logger.error(match { it.data == expectedLog.data }) }
+    }
+
+    @Test
+    fun testSaveOnScreenTime_shouldLogAppEventLogWithInfo_whenLoadingTimeIsNull() {
+        every { mockTimestampProvider.provideTimestamp() } returns 100L
+
+        val args = Bundle()
+        args.putString(IamDialog.CAMPAIGN_ID, CAMPAIGN_ID)
+        args.putString(IamDialog.REQUEST_ID, REQUEST_ID_KEY)
+
+        iamDialog.arguments = args
+
+        val expectedLog = AppEventLog(
+            "reporting iamDialog",
+            mapOf(
+                "message" to "iamDialog - loadingTime is null",
+                "campaignId" to CAMPAIGN_ID
+            )
+        )
+
+        try {
+            iamDialog.dismiss()
+        } catch (e: IllegalStateException) {
+            // Testing private fun saveOnScreenTime() here
+            // Catch and ignore IllegalStateException thrown by super.dismiss()
+        }
+
+        verify { Logger.info(match { it.data == expectedLog.data }) }
     }
 
     private fun createWebView(): IamWebView {

--- a/mobile-engage/src/androidTest/java/com/emarsys/mobileengage/iam/dialog/IamDialogTest.kt
+++ b/mobile-engage/src/androidTest/java/com/emarsys/mobileengage/iam/dialog/IamDialogTest.kt
@@ -691,7 +691,7 @@ class IamDialogTest {
         } catch (ignoredExceptionFromSuper: IllegalStateException) {
         }
 
-        verify { Logger.info(match { it.topic == expectedLog.topic && it.data == expectedLog.data }) }
+        verify { Logger.debug(match { it.topic == expectedLog.topic && it.data == expectedLog.data }) }
     }
 
     private fun createWebView(): IamWebView {

--- a/mobile-engage/src/androidTest/java/com/emarsys/mobileengage/request/MobileEngageRequestModelFactoryTest.kt
+++ b/mobile-engage/src/androidTest/java/com/emarsys/mobileengage/request/MobileEngageRequestModelFactoryTest.kt
@@ -3,7 +3,6 @@ package com.emarsys.mobileengage.request
 
 import com.emarsys.common.feature.InnerFeature
 import com.emarsys.core.api.notification.NotificationSettings
-import com.emarsys.core.util.TimestampUtils
 import com.emarsys.core.device.DeviceInfo
 import com.emarsys.core.endpoint.ServiceEndpointProvider
 import com.emarsys.core.feature.FeatureRegistry
@@ -12,6 +11,7 @@ import com.emarsys.core.provider.uuid.UUIDProvider
 import com.emarsys.core.request.model.RequestMethod
 import com.emarsys.core.request.model.RequestModel
 import com.emarsys.core.storage.StringStorage
+import com.emarsys.core.util.TimestampUtils
 import com.emarsys.mobileengage.MobileEngageRequestContext
 import com.emarsys.mobileengage.iam.model.buttonclicked.ButtonClicked
 import com.emarsys.mobileengage.iam.model.buttonclicked.ButtonClickedRepository
@@ -383,5 +383,28 @@ class MobileEngageRequestModelFactoryTest  {
         val events = result.payload!!["events"] as List<*>
         val event = events[0] as Map<*, *>
         event["timestamp"] shouldBe TimestampUtils.formatTimestampWithUTC(triggerTimestamp)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testCreateTrackDeviceInfoRequest_throwsIllegalArgumentException_whenApplicationCodeIsEmptyString() {
+        val contextWithEmptyCode = mock<MobileEngageRequestContext> {
+            on { timestampProvider } doReturn mockTimestampProvider
+            on { uuidProvider } doReturn mockUuidProvider
+            on { deviceInfo } doReturn mockDeviceInfo
+            on { applicationCode } doReturn ""
+            on { refreshTokenStorage } doReturn mockRefreshTokenStorage
+            on { contactFieldValue } doReturn null
+            on { contactFieldId } doReturn CONTACT_FIELD_ID
+            on { sessionIdHolder } doReturn mock()
+        }
+        val factory = MobileEngageRequestModelFactory(
+            contextWithEmptyCode,
+            mockClientServiceProvider,
+            mockEventServiceProvider,
+            mockMessageInboxServiceProvider,
+            mockButtonClickedRepository
+        )
+
+        factory.createTrackDeviceInfoRequest()
     }
 }

--- a/mobile-engage/src/main/java/com/emarsys/mobileengage/deeplink/DeepLinkAction.kt
+++ b/mobile-engage/src/main/java/com/emarsys/mobileengage/deeplink/DeepLinkAction.kt
@@ -13,9 +13,10 @@ class DeepLinkAction(private val deepLinkInternal: DeepLinkInternal,
 ) : ActivityLifecycleAction {
 
     override fun execute(activity: Activity?) {
-        if (activity != null && activity.intent != null) {
+        val intent = activity?.intent
+        if (activity != null && intent != null) {
             deepLinkInternal.proxyApi(mobileEngage().concurrentHandlerHolder)
-                .trackDeepLinkOpen(activity, activity.intent, null)
+                .trackDeepLinkOpen(activity, intent, null)
         }
     }
 }

--- a/mobile-engage/src/main/java/com/emarsys/mobileengage/iam/dialog/IamDialog.kt
+++ b/mobile-engage/src/main/java/com/emarsys/mobileengage/iam/dialog/IamDialog.kt
@@ -15,8 +15,8 @@ import androidx.fragment.app.DialogFragment
 import com.emarsys.core.Mockable
 import com.emarsys.core.provider.timestamp.TimestampProvider
 import com.emarsys.core.util.AndroidVersionUtils
+import com.emarsys.core.util.log.Logger.Companion.debug
 import com.emarsys.core.util.log.Logger.Companion.error
-import com.emarsys.core.util.log.Logger.Companion.info
 import com.emarsys.core.util.log.Logger.Companion.metric
 import com.emarsys.core.util.log.entry.AppEventLog
 import com.emarsys.core.util.log.entry.InAppLoadingTime
@@ -230,7 +230,7 @@ class IamDialog(
                     )
                 )
             } else if (loadingTime == null) {
-                info(
+                debug(
                     AppEventLog(
                         "reporting iamDialog",
                         mapOf(

--- a/mobile-engage/src/main/java/com/emarsys/mobileengage/iam/dialog/IamDialog.kt
+++ b/mobile-engage/src/main/java/com/emarsys/mobileengage/iam/dialog/IamDialog.kt
@@ -16,6 +16,7 @@ import com.emarsys.core.Mockable
 import com.emarsys.core.provider.timestamp.TimestampProvider
 import com.emarsys.core.util.AndroidVersionUtils
 import com.emarsys.core.util.log.Logger.Companion.error
+import com.emarsys.core.util.log.Logger.Companion.info
 import com.emarsys.core.util.log.Logger.Companion.metric
 import com.emarsys.core.util.log.entry.AppEventLog
 import com.emarsys.core.util.log.entry.InAppLoadingTime
@@ -219,18 +220,39 @@ class IamDialog(
         updateOnScreenTime()
         val args = arguments
         if (args != null) {
-            metric(
-                InAppLog(
-                    args.getSerializable(LOADING_TIME)!! as InAppLoadingTime,
-                    OnScreenTime(
-                        args.getLong(ON_SCREEN_TIME),
-                        startTime,
-                        args.getLong(END_SCREEN_TIME)
-                    ),
-                    args.getString(CAMPAIGN_ID)!!,
-                    args.getString(REQUEST_ID)
+            val loadingTime = args.getSerializable(LOADING_TIME) as? InAppLoadingTime
+            val campaignId = args.getString(CAMPAIGN_ID)
+            if (campaignId == null) {
+                error(
+                    AppEventLog(
+                        "reporting iamDialog",
+                        mapOf("error" to "iamDialog - campaignId is null")
+                    )
                 )
-            )
+            } else if (loadingTime == null) {
+                info(
+                    AppEventLog(
+                        "reporting iamDialog",
+                        mapOf(
+                            "message" to "iamDialog - loadingTime is null",
+                            "campaignId" to campaignId
+                        )
+                    )
+                )
+            } else {
+                metric(
+                    InAppLog(
+                        loadingTime,
+                        OnScreenTime(
+                            args.getLong(ON_SCREEN_TIME),
+                            startTime,
+                            args.getLong(END_SCREEN_TIME)
+                        ),
+                        campaignId,
+                        args.getString(REQUEST_ID)
+                    )
+                )
+            }
         } else {
             error(
                 AppEventLog(


### PR DESCRIPTION
# Bug Fixes: In-App Crashes, SharedPreferences Security, and Empty Application Code Handling

### Bug Fix

🐛 This PR addresses several stability and correctness issues across the Emarsys Android SDK, including crash prevention for In-App messages, safer SharedPreferences encryption/decryption, proper handling of empty application codes, and improved error logging.

### Changes

* `.github/workflows/on_push_workflow.yml`: Removed hardcoded `ref: dev` checkout override so CI tests run against the actual branch being pushed.

* `changelog.md`: Updated changelog to document fixes for In-App crash on display failure and `InlineInAppView` main-thread initialization issue.

* `core/.../SharedPreferenceCrypto.kt`: Made `secretKey` nullable and wrapped initialization in a try/catch to avoid crashes when the Android Keystore is unavailable. Improved error handling in `encrypt`/`decrypt` recovery paths to also catch `ProviderException` during secret key creation. `tryEncrypt` now accepts the key as a parameter instead of referencing the field directly.

* `core/.../SharedPreferenceCryptoTest.kt`: Added tests covering `ProviderException` during key generation recovery, and `KeyStoreException` during initialization — verifying no crash is thrown.

* `core/.../ExceptionExtensions.kt`: Added `ResponseErrorException` to the list of network exceptions so HTTP error responses are treated as network-level failures and not logged as crashes.

* `core/.../LogExceptionProxyTest.kt`: Added test to verify that `ResponseErrorException` does not trigger an error crash log.

* `emarsys-sdk/.../EmarsysConfig.kt`: `applicationCode` is now normalized — an empty string is treated as `null` during `build()`.

* `emarsys-sdk/.../EmarsysConfigTest.kt`: Added test to verify that an empty `applicationCode` string yields `null` in the built config.

* `emarsys/.../DefaultConfigInternal.kt`: `handleAppCodeChange` normalizes empty application codes to `null`, preventing improper SDK behavior when an empty string is passed.

* `emarsys/.../DefaultConfigInternalTest.kt`: Added tests verifying that `changeApplicationCode("")` treats the code as `null` and does not throw on subsequent SDK calls.

* `emarsys-sdk/.../InlineInAppView.kt`: WebView factory creation is now always dispatched on the main thread via a new `runOnMain` helper, fixing crashes when `InlineInAppView` is created from a background thread.

* `emarsys-sdk/.../InlineInAppViewTest.kt`: Added test ensuring the WebView factory is called on the main thread even when `InlineInAppView` is constructed on a background thread.

* `mobile-engage/.../IamDialog.kt`: `saveOnScreenTime` now safely handles null `campaignId` and null `loadingTime` — logging appropriate error/debug entries instead of force-unwrapping and crashing.

* `mobile-engage/.../IamDialogTest.kt`: Added tests for `saveOnScreenTime` covering null arguments, null `campaignId`, null `loadingTime`, and the normal success path.

* `mobile-engage/.../DeepLinkAction.kt`: Captured `activity.intent` into a local variable before the null check to avoid a race condition where intent could become null between the check and its use.

* `mobile-engage/.../DeepLinkActionTest.kt`: Added test for the race condition scenario where intent becomes null between check and use.

* `mobile-engage/.../MobileEngageRequestModelFactoryTest.kt`: Added test verifying that `createTrackDeviceInfoRequest` throws `IllegalArgumentException` when `applicationCode` is an empty string.

- [ ] 🔄 Regenerate and Update Summary



<details>
<summary>PR Bot Information</summary>

**Version:** `1.29.54`

- Output Template: [Default Template](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_default_output_template.md)
- File Content Strategy: Full file content
- LLM: `anthropic--claude-4.6-sonnet`
- Summary Prompt: [Default Prompt](https://github.tools.sap/Code-Change-Intelligence/pr-bot/blob/main/src/services/llm/prompts/summary_instructions_prompt.md)
- Correlation ID: `ebabac00-a217-11f1-81a9-175918564d7b`
- Event Trigger: `pull_request.opened`
</details>
